### PR TITLE
The try out URL has changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A simple tool for converting images into pxt-arcade's format.
 
 ## Try it out
 
-https://riknoll.github.io/pxt-editor-extension-sample
+https://riknoll.github.io/pxt-arcade-asset-tool/
 
 ## Build
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "pxt-editor-extension-sample",
     "version": "0.0.1",
     "description": "A MakeCode editor extension sample",
-    "homepage": "https://samelhusseini.github.io/pxt-editor-extension-sample/",
+    "homepage": "https://riknoll.github.io/pxt-arcade-asset-tool/",
     "scripts": {
         "build:dev": "./node_modules/.bin/webpack --mode development --config webpack.dev.js",
         "build:prod": "./node_modules/.bin/webpack --mode production --config webpack.prod.js",


### PR DESCRIPTION
I discovered this nice tool through Adafruit : https://learn.adafruit.com/next-level-makecode-arcade-games/asset-tool#asset-conversion-3-8
The URL here was not working anymore, but the URL from the article still works.